### PR TITLE
Fix Cell equality handling in pathfinding algorithms

### DIFF
--- a/src/Cell.java
+++ b/src/Cell.java
@@ -29,6 +29,25 @@ public class Cell {
         return "(" + row + ", " + column + ")";
     }
 
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof Cell)) {
+            return false;
+        }
+        Cell other = (Cell) obj;
+        return this.row == other.row && this.column == other.column;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Integer.hashCode(row);
+        result = 31 * result + Integer.hashCode(column);
+        return result;
+    }
+
     //set status for current cell - if is start
     public void setStart(boolean start) {
         isStart = start;

--- a/src/PathfindingAlgorithms.java
+++ b/src/PathfindingAlgorithms.java
@@ -11,6 +11,9 @@ public class PathfindingAlgorithms {
 
     //bfs - breadth first search method to use
     public static void bfs(Grid grid, Cell start, Cell goal) {
+        // normalize start and goal to cells from the grid
+        start = grid.getCell(start.getRow(), start.getColumn());
+        goal = grid.getCell(goal.getRow(), goal.getColumn());
         //create queue to track visited cells, prevent repeats, and map cell to cell for parent to child relationship
         Queue<Cell> frontier = new LinkedList<>();
         Map<Cell, Cell> path = new HashMap<>();
@@ -24,7 +27,7 @@ public class PathfindingAlgorithms {
         //once goal is found the loop breaks
         while (!frontier.isEmpty()) {
             Cell current = frontier.poll();
-            if (current == goal) {
+            if (current.equals(goal)) {
                 break;
             }
 
@@ -60,6 +63,9 @@ public class PathfindingAlgorithms {
     }
 
     public static void dfs(Grid grid, Cell start, Cell goal) {
+        // normalize start and goal to cells from the grid
+        start = grid.getCell(start.getRow(), start.getColumn());
+        goal = grid.getCell(goal.getRow(), goal.getColumn());
         //dfs uses stack, map parent child relationship
         Stack<Cell> frontier = new Stack<>();
         Map<Cell, Cell> path = new HashMap<>();
@@ -74,7 +80,7 @@ public class PathfindingAlgorithms {
             Cell current = frontier.pop();
 
             //finds goal - code breaks
-            if (current == goal) {
+            if (current.equals(goal)) {
                 break;
             }
 


### PR DESCRIPTION
## Summary
- define `equals` and `hashCode` for `Cell`
- normalize the start and goal cells in BFS and DFS before exploration
- compare cells using `equals` when searching

## Testing
- `javac src/*.java && echo "compiled"`


------
https://chatgpt.com/codex/tasks/task_e_683f8a8fee608324a5872e45f468966e